### PR TITLE
Update build instructions in COMPILE.md

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -7,22 +7,27 @@ fully supported minus the WebView2 map, which falls back to a text notice.
 - [Building on Windows](#building-on-windows)
 - [Building on Linux](#building-on-linux)
 
-# Building on Windows
+## Building on Windows
 
 InmarScope is built with the **MSYS2 / MinGW-w64** toolchain (GCC 15.x) using
 **CMake** and **Ninja**. The build is reproducible from a clean MSYS2 install.
 
-> Important: GCC must be invoked from inside the **MINGW64** environment. If you
+> [!WARNING]
+> GCC must be invoked from inside the **MINGW64** environment. If you
 > run `g++.exe` directly from PowerShell/cmd without that environment set up,
 > `cc1plus` dies silently with exit code 1 and no diagnostics. Always build from
 > the **MSYS2 MINGW64** shell (or set `MSYSTEM=MINGW64` before launching bash).
 
-## 1. Install MSYS2
+### 1. Install MSYS2
 
-Download and install from <https://www.msys2.org>, then open the
-**"MSYS2 MINGW64"** shell (not the plain "MSYS2 MSYS" shell) from the Start menu.
+Download and install MSYS2 from [msys2.org](https://www.msys2.org) (`msys2-x86_64-*.exe`)
 
-Update the package database once:
+> [!IMPORTANT]
+> The **UCRT64** shell will open on-screen after installing, close it afterwards.
+
+Open the **"MSYS2 MINGW64"** shell from the Start menu. (has a blue icon, not the plain "MSYS2 MSYS" shell) 
+
+Inside of the shell window, update the package database:
 
 ```bash
 pacman -Syu
@@ -30,10 +35,13 @@ pacman -Syu
 pacman -Su
 ```
 
-## 2. Install build tools and dependencies
+### 2. Install build tools and dependencies
+
+Install these packages through the **MINGW64** shell window:
 
 ```bash
 pacman -S --needed \
+  mingw-w64-x86_64-git \
   mingw-w64-x86_64-toolchain \
   mingw-w64-x86_64-cmake \
   mingw-w64-x86_64-ninja \
@@ -50,7 +58,7 @@ pacman -S --needed \
   mingw-w64-x86_64-jansson
 ```
 
-These provide: GCC/G++, CMake, Ninja, pkg-config, GLFW (windowing), librtlsdr +
+These provide: Git, GCC/G++, CMake, Ninja, pkg-config, GLFW (windowing), librtlsdr +
 libusb (RTL-SDR), HackRF, and zstd (SDR++ server compression). OpenGL and zlib
 ship with the toolchain. libogg + libvorbis provide OGG Vorbis voice recording.
 SQLite3 provides the message archive database.  libxml2 is required
@@ -60,16 +68,36 @@ All other dependencies (Dear ImGui, ImPlot, the JAERO DSP, mbelib, libacars,
 miniaudio, WebView2 SDK) are vendored in `third_party/` — the repo is fully
 self-contained. **No `git submodule` commands are needed.**
 
-### Optional: Airspy support
+#### Optional: Airspy support
+
+Because MSYS2 does not have a `libairspy` package available, you must build and install it.
+
+Build and install the `libairspy` libary through these commands in the **MINGW64** shell:
 
 ```bash
-pacman -S --needed mingw-w64-x86_64-libairspy
+git clone https://github.com/airspy/airspyone_host.git
+cd airspyone_host
+cmake . -B build -G "MinGW Makefiles"
+mingw32-make.exe -C build clean all install
+# return back to the starting directory
+cd ..
 ```
+
+View more information at the [airspy/airspyone_host](https://github.com/airspy/airspyone_host) repository.
 
 Airspy headers are vendored in `third_party/airspy/`. The build automatically
 enables Airspy (`HAS_AIRSPY=1`) when libairspy is found by CMake.
 
-## 3. Configure and build
+### 3. Clone the InmarScope repository
+
+Obtain the project source code using Git in the **MINGW64** shell:
+
+```bash
+git clone https://github.com/SarahRoseLives/InmarScope.git
+cd InmarScope
+```
+
+### 4. Configure and build
 
 From the **MINGW64** shell, in the project root:
 
@@ -80,7 +108,7 @@ ninja -C build
 
 The executable and the runtime DLLs it needs are placed in `build/`:
 
-```
+```text
 build/InmarScope.exe
 build/libgcc_s_seh-1.dll, libwinpthread-1.dll, libstdc++-6.dll,
       glfw3.dll, librtlsdr.dll, libhackrf.dll, libusb-1.0.dll,
@@ -89,6 +117,7 @@ build/libgcc_s_seh-1.dll, libwinpthread-1.dll, libstdc++-6.dll,
       libxml2-16.dll, libiconv-2.dll, liblzma-5.dll,
       libjansson-4.dll, WebView2Loader.dll
 ```
+
 (plus `build/libairspy.dll` when Airspy support is enabled)
 
 The DLLs are copied next to the `.exe` automatically (POST_BUILD step), so it
@@ -100,7 +129,7 @@ Run it:
 ./build/InmarScope.exe
 ```
 
-## 4. Building from PowerShell (optional)
+### 5. Building from PowerShell (optional)
 
 If you prefer to drive the build from PowerShell, you must enter the MINGW64
 environment first. For example:
@@ -115,7 +144,7 @@ The `-l` (login) shell with `MSYSTEM=MINGW64` sources `/etc/profile`, which puts
 `/mingw64/bin` on `PATH` so `cc1plus` can find its runtime. `CHERE_INVOKING=1`
 keeps the current directory.
 
-## Notes / troubleshooting
+### Notes / troubleshooting
 
 - **First build is slow (~1 min on `implot_items.cpp`).** ImPlot's
   `implot_items.cpp` is extremely template-heavy; at `-O2` it takes ~5 minutes
@@ -130,9 +159,8 @@ keeps the current directory.
 - **Clean rebuild.** Delete the `build/` directory and re-run the configure +
   build steps. (Avoid `--clean-first`; it wipes the vendored objects and forces
   the slow `implot_items.cpp` recompile.)
-```
 
-# Building on Linux
+## Building on Linux
 
 InmarScope builds natively on Linux with **GCC/Clang**, **CMake**, and
 **Ninja**. The build uses the same `CMakeLists.txt` as Windows; the WebView2
@@ -140,12 +168,13 @@ Flight Map is Windows-only and is automatically skipped — the Flight Map panel
 is hidden entirely on Linux. Everything else (decoding, voice,
 spectrum/waterfall, web dashboard, SBS output) works.
 
-## 1. Install build tools and dependencies
+### 1. Install build tools and dependencies
 
 On **Debian / Ubuntu**:
 
 ```bash
 sudo apt-get install -y \
+  git \
   build-essential cmake ninja-build pkg-config \
   libglfw3-dev libgl1-mesa-dev \
   librtlsdr-dev libhackrf-dev libusb-1.0-0-dev \
@@ -158,6 +187,7 @@ On **Arch / Manjaro**:
 
 ```bash
 sudo pacman -S --needed \
+  git \
   base-devel cmake ninja pkgconf \
   glfw rtl-sdr hackrf libusb \
   zstd zlib libogg libvorbis \
@@ -168,6 +198,7 @@ On **Fedora**:
 
 ```bash
 sudo dnf install -y \
+  git \
   gcc-c++ cmake ninja-build pkgconf-pkg-config \
   glfw-devel mesa-libGL-devel \
   rtl-sdr-devel hackrf-devel libusb1-devel \
@@ -180,13 +211,22 @@ As on Windows, all remaining dependencies (Dear ImGui, ImPlot, the JAERO DSP,
 mbelib, libacars, miniaudio) are vendored in `third_party/` — no submodules
 needed.
 
-### Optional: Airspy support
+#### Optional: Airspy support
 
 Install `libairspy-dev` (Debian/Ubuntu), `airspy` (Arch), or `airspy-devel`
 (Fedora). The build enables Airspy (`HAS_AIRSPY=1`) automatically when libairspy
 is found by CMake.
 
-## 2. Configure and build
+### 2. Clone the InmarScope repository
+
+Obtain the project source code using Git:
+
+```bash
+git clone https://github.com/SarahRoseLives/InmarScope.git
+cd InmarScope
+```
+
+### 3. Configure and build
 
 ```bash
 cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
@@ -200,7 +240,7 @@ Run it from the project root (so it finds the bundled font under
 ./build/InmarScope
 ```
 
-## Notes / troubleshooting
+### Notes / troubleshooting
 
 - **First build is slow (~1 min on `implot_items.cpp`).** Same template-heavy
   file as on Windows; CMakeLists.txt already caps it at `-O1`.


### PR DESCRIPTION
I was trying to build InmarScope by following the instructions verbatim and noticed there were flaws.

Notably, MSYS2 does not provide a package for `libairspy` so the option would be to build and install it.

I used [Windows Sandbox](https://learn.microsoft.com/en-us/windows/security/application-security/application-isolation/windows-sandbox/) to test these instructions to build InmarScope.

Please let me know what you think about these changes, thank you.