### PR TITLE
Add touchpad pinch-to-zoom support for Windows and Linux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,6 +131,49 @@ int main(int, char**)
         glfwTerminate();
         return 1;
     }
+
+#if defined(_WIN32)
+	using RegisterTouchpadCapableThreadFn = BOOL (WINAPI *)(BOOL);
+
+	HMODULE user32 = GetModuleHandleW(L"user32.dll");
+	auto pRegisterTouchpadCapableThread =
+		reinterpret_cast<RegisterTouchpadCapableThreadFn>(
+			GetProcAddress(user32, "RegisterTouchpadCapableThread"));
+
+	if (pRegisterTouchpadCapableThread)
+	{
+		if (!pRegisterTouchpadCapableThread(TRUE))
+		{
+			fprintf(stderr,
+				"[WIN32] RegisterTouchpadCapableThread failed: %lu\n",
+				GetLastError());
+		}
+
+	}
+	else
+	{
+		fprintf(stderr,
+			"[WIN32] RegisterTouchpadCapableThread not available\n");
+	}
+
+	// Register keyboard Raw Input to distinguish physical Ctrl
+	// from the Ctrl synthesized by Windows for touchpad pinch gestures.
+	HWND hWnd = glfwGetWin32Window(window);
+
+	RAWINPUTDEVICE keyboardRid = {};
+	keyboardRid.usUsagePage = 0x01;   // Generic Desktop Controls
+	keyboardRid.usUsage     = 0x06;   // Keyboard
+	keyboardRid.dwFlags     = RIDEV_INPUTSINK;
+	keyboardRid.hwndTarget  = hWnd;
+
+	if (!RegisterRawInputDevices(&keyboardRid, 1, sizeof(keyboardRid)))
+	{
+		fprintf(stderr,
+			"[WIN32] Raw keyboard registration failed: %lu\n",
+			GetLastError());
+	}
+#endif
+
     glfwMakeContextCurrent(window);
     glfwSwapInterval(1);
 

--- a/third_party/imgui/backends/imgui_impl_glfw.cpp
+++ b/third_party/imgui/backends/imgui_impl_glfw.cpp
@@ -162,6 +162,20 @@
 #ifndef GLFW_EXPOSE_NATIVE_X11      // for glfwGetX11Display(), glfwGetX11Window() on Freedesktop (Linux, BSD, etc.)
 #define GLFW_EXPOSE_NATIVE_X11
 #include <X11/Xatom.h>
+
+#ifndef IMGUI_IMPL_GLFW_HAS_XINPUT2
+#if defined(__has_include)
+#if __has_include(<X11/extensions/XInput2.h>)
+#include <X11/extensions/XInput2.h>
+#define IMGUI_IMPL_GLFW_HAS_XINPUT2 1
+#endif
+#endif
+#endif
+
+#ifndef IMGUI_IMPL_GLFW_HAS_XINPUT2
+#define IMGUI_IMPL_GLFW_HAS_XINPUT2 0
+#endif
+
 #include <dlfcn.h>              // for dlopen()
 #endif
 #include <GLFW/glfw3native.h>
@@ -236,6 +250,19 @@ typedef Atom (*PFN_XInternAtom)(Display*, const char* ,Bool);
 typedef int  (*PFN_XChangeProperty)(Display*, Window, Atom, Atom, int, int, const unsigned char*, int);
 typedef int  (*PFN_XChangeWindowAttributes)(Display*, Window, unsigned long, XSetWindowAttributes*);
 typedef int  (*PFN_XFlush)(Display*);
+
+#if IMGUI_IMPL_GLFW_HAS_XINPUT2
+typedef int (*PFN_XIQueryVersion)(Display*, int*, int*);
+typedef int (*PFN_XISelectEvents)(Display*, Window, XIEventMask*, int);
+typedef Display* (*PFN_XOpenDisplay)(const char*);
+typedef int      (*PFN_XCloseDisplay)(Display*);
+typedef int      (*PFN_XPending)(Display*);
+typedef int      (*PFN_XNextEvent)(Display*, XEvent*);
+typedef Bool     (*PFN_XGetEventData)(Display*, XGenericEventCookie*);
+typedef void     (*PFN_XFreeEventData)(Display*, XGenericEventCookie*);
+typedef Bool     (*PFN_XQueryExtension)(Display*, const char*, int*, int*, int*);
+#endif
+
 #endif
 
 // GLFW data
@@ -282,6 +309,26 @@ struct ImGui_ImplGlfw_Data
     PFN_XChangeProperty         XChangeProperty;
     PFN_XChangeWindowAttributes XChangeWindowAttributes;
     PFN_XFlush                  XFlush;
+
+#if IMGUI_IMPL_GLFW_HAS_XINPUT2
+    PFN_XOpenDisplay            XOpenDisplay;
+    PFN_XCloseDisplay           XCloseDisplay;
+    PFN_XPending                XPending;
+    PFN_XNextEvent              XNextEvent;
+    PFN_XGetEventData           XGetEventData;
+    PFN_XFreeEventData          XFreeEventData;
+    PFN_XQueryExtension         XQueryExtension;
+
+    void*                       XiModule;
+    PFN_XIQueryVersion          XIQueryVersion;
+    PFN_XISelectEvents          XISelectEvents;
+
+    Display*                    PinchDisplay;
+    ::Window                    PinchWindow;
+    int                         PinchXiOpcode;
+    double                      PinchLastScale;
+    bool                        PinchActive;
+#endif
 #endif
 
     ImGui_ImplGlfw_Data()   { memset((void*)this, 0, sizeof(*this)); }
@@ -842,9 +889,102 @@ static bool ImGui_ImplGlfw_Init(GLFWwindow* window, bool install_callbacks, Glfw
         bd->XChangeProperty = (PFN_XChangeProperty)dlsym(bd->X11Module, "XChangeProperty");
         bd->XChangeWindowAttributes = (PFN_XChangeWindowAttributes)dlsym(bd->X11Module, "XChangeWindowAttributes");
         bd->XFlush = (PFN_XFlush)dlsym(bd->X11Module, "XFlush");
+
         IM_ASSERT(bd->XInternAtom != nullptr && bd->XChangeProperty != nullptr && bd->XChangeWindowAttributes != nullptr && bd->XFlush != nullptr);
-    }
+
+#if IMGUI_IMPL_GLFW_HAS_XINPUT2
+            bd->XOpenDisplay =
+                (PFN_XOpenDisplay)dlsym(bd->X11Module, "XOpenDisplay");
+            bd->XCloseDisplay =
+                (PFN_XCloseDisplay)dlsym(bd->X11Module, "XCloseDisplay");
+            bd->XPending =
+                (PFN_XPending)dlsym(bd->X11Module, "XPending");
+            bd->XNextEvent =
+                (PFN_XNextEvent)dlsym(bd->X11Module, "XNextEvent");
+            bd->XGetEventData =
+                (PFN_XGetEventData)dlsym(bd->X11Module, "XGetEventData");
+            bd->XFreeEventData =
+                (PFN_XFreeEventData)dlsym(bd->X11Module, "XFreeEventData");
+            bd->XQueryExtension =
+                (PFN_XQueryExtension)dlsym(bd->X11Module, "XQueryExtension");
+
+            IM_ASSERT(bd->XOpenDisplay != nullptr &&
+                bd->XCloseDisplay != nullptr &&
+                bd->XPending != nullptr &&
+                bd->XNextEvent != nullptr &&
+                bd->XGetEventData != nullptr &&
+                bd->XFreeEventData != nullptr &&
+                bd->XQueryExtension != nullptr);
+
+#if defined(__CYGWIN__)
+        const char* xi_module_path = "libXi-6.so";
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
+        const char* xi_module_path = "libXi.so";
+#else
+        const char* xi_module_path = "libXi.so.6";
 #endif
+
+        bd->XiModule = dlopen(xi_module_path, RTLD_LAZY | RTLD_LOCAL);
+        if (bd->XiModule != nullptr)
+        {
+            bd->XIQueryVersion =
+                (PFN_XIQueryVersion)dlsym(bd->XiModule, "XIQueryVersion");
+
+            bd->XISelectEvents =
+                (PFN_XISelectEvents)dlsym(bd->XiModule, "XISelectEvents");
+        }
+
+        if (bd->XiModule != nullptr &&
+            bd->XIQueryVersion != nullptr &&
+            bd->XISelectEvents != nullptr)
+        {
+            bd->PinchDisplay = bd->XOpenDisplay(nullptr);
+
+            if (bd->PinchDisplay != nullptr)
+            {
+                int event_base = 0;
+                int error_base = 0;
+
+                if (bd->XQueryExtension(bd->PinchDisplay,
+                    "XInputExtension",
+                    &bd->PinchXiOpcode,
+                    &event_base,
+                    &error_base))
+                {
+                    int major = 2;
+                    int minor = 4;
+
+                    int rc = bd->XIQueryVersion(bd->PinchDisplay,
+                        &major,
+                        &minor);
+                    if (rc == Success &&
+                        (major > 2 || (major == 2 && minor >= 4)))
+                    {
+                        bd->PinchWindow = glfwGetX11Window(bd->Window);
+
+                        unsigned char mask[XIMaskLen(XI_LASTEVENT)] = {};
+                        XISetMask(mask, XI_GesturePinchBegin);
+                        XISetMask(mask, XI_GesturePinchUpdate);
+                        XISetMask(mask, XI_GesturePinchEnd);
+
+                        XIEventMask event_mask = {};
+                        event_mask.deviceid = XIAllMasterDevices;
+                        event_mask.mask_len = sizeof(mask);
+                        event_mask.mask = mask;
+
+                        bd->XISelectEvents(bd->PinchDisplay,
+                                        bd->PinchWindow,
+                                        &event_mask,
+                                        1);
+
+                        bd->XFlush(bd->PinchDisplay);
+                    }
+                }
+            }
+        }
+#endif      // IMGUI_IMPL_GLFW_HAS_XINPUT2
+    }
+#endif      // GLFW_HAS_X11
 
     // Emscripten: the same application can run on various platforms, so we detect the Apple platform at runtime
     // to override io.ConfigMacOSXBehaviors from its default (which is always false in Emscripten).
@@ -907,6 +1047,20 @@ void ImGui_ImplGlfw_Shutdown()
     ::SetPropA((HWND)main_viewport->PlatformHandleRaw, "IMGUI_BACKEND_DATA", nullptr);
     ::SetWindowLongPtrW((HWND)main_viewport->PlatformHandleRaw, GWLP_WNDPROC, (LONG_PTR)bd->PrevWndProc);
     bd->PrevWndProc = nullptr;
+#endif
+
+#if GLFW_HAS_X11 && IMGUI_IMPL_GLFW_HAS_XINPUT2
+    if (bd->PinchDisplay != nullptr && bd->XCloseDisplay != nullptr)
+    {
+        bd->XCloseDisplay(bd->PinchDisplay);
+        bd->PinchDisplay = nullptr;
+    }
+
+    if (bd->XiModule != nullptr)
+    {
+        dlclose(bd->XiModule);
+        bd->XiModule = nullptr;
+    }
 #endif
 
 #if GLFW_HAS_X11
@@ -1216,6 +1370,55 @@ void ImGui_ImplGlfw_NewFrame()
     bd->MouseIgnoreButtonUp = false;
     ImGui_ImplGlfw_UpdateMouseData();
     ImGui_ImplGlfw_UpdateMouseCursor();
+
+#if GLFW_HAS_X11 && IMGUI_IMPL_GLFW_HAS_XINPUT2
+    if (bd->PinchDisplay != nullptr)
+    {
+        while (bd->XPending(bd->PinchDisplay) > 0)
+        {
+            XEvent event;
+            bd->XNextEvent(bd->PinchDisplay, &event);
+
+            if (event.type == GenericEvent &&
+                event.xcookie.extension == bd->PinchXiOpcode &&
+                bd->XGetEventData(bd->PinchDisplay, &event.xcookie))
+            {
+                if (event.xcookie.evtype == XI_GesturePinchBegin)
+                {
+                    bd->PinchActive = true;
+                    bd->PinchLastScale = 1.0;
+                }
+                else if (event.xcookie.evtype == XI_GesturePinchUpdate)
+                {
+                    XIGesturePinchEvent* pinch =
+                        static_cast<XIGesturePinchEvent*>(event.xcookie.data);
+
+                    if (bd->PinchActive)
+                    {
+                        double ratio = pinch->scale / bd->PinchLastScale;
+
+                        if (!io.KeyCtrl)
+                        {
+                            if (ratio > 1.001)
+                                io.AddMouseWheelEvent(0.0f, 0.1f);
+                            else if (ratio < 0.999)
+                                io.AddMouseWheelEvent(0.0f, -0.1f);
+                        }
+
+                        bd->PinchLastScale = pinch->scale;
+                    }
+                }
+                else if (event.xcookie.evtype == XI_GesturePinchEnd)
+                {
+                    bd->PinchActive = false;
+                    bd->PinchLastScale = 1.0;
+                }
+
+                bd->XFreeEventData(bd->PinchDisplay, &event.xcookie);
+            }
+        }
+    }
+#endif
 
     // Update game controllers (if enabled and available)
     ImGui_ImplGlfw_UpdateGamepads();

--- a/third_party/imgui/backends/imgui_impl_glfw.cpp
+++ b/third_party/imgui/backends/imgui_impl_glfw.cpp
@@ -145,6 +145,7 @@
 #else
 #define GLFW_HAS_WAYLAND    0
 #endif
+
 #include <GLFW/glfw3.h>
 #ifdef _WIN32
 #undef APIENTRY
@@ -651,6 +652,8 @@ static EM_BOOL ImGui_ImplEmscripten_WheelCallback(int, const EmscriptenWheelEven
 #endif
 
 #ifdef _WIN32
+static bool g_PhysicalCtrlDown = false;
+
 static LRESULT CALLBACK ImGui_ImplGlfw_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 #endif
 
@@ -1685,6 +1688,69 @@ static LRESULT CALLBACK ImGui_ImplGlfw_WndProc(HWND hWnd, UINT msg, WPARAM wPara
     if (viewport != NULL)
         if (ImGui_ImplGlfw_ViewportData* vd = (ImGui_ImplGlfw_ViewportData*)viewport->PlatformUserData)
             prev_wndproc = vd->PrevWndProc;
+
+    switch (msg)
+    {
+	case WM_INPUT:
+	{
+		UINT size = 0;
+
+		if (GetRawInputData((HRAWINPUT)lParam,
+                        RID_INPUT,
+                        nullptr,
+                        &size,
+                        sizeof(RAWINPUTHEADER)) == 0 &&
+			size > 0)
+		{
+			BYTE buffer[256];
+
+			if (size <= sizeof(buffer) &&
+				GetRawInputData((HRAWINPUT)lParam,
+					RID_INPUT,
+					buffer,
+					&size,
+					sizeof(RAWINPUTHEADER)) == size)
+			{
+				RAWINPUT* raw =
+					reinterpret_cast<RAWINPUT*>(buffer);
+
+				if (raw->header.dwType == RIM_TYPEKEYBOARD)
+				{
+					const RAWKEYBOARD& kb = raw->data.keyboard;
+
+					// Physical Ctrl has a hardware scan code.
+					// Ctrl synthesized by Windows for touchpad pinch has MakeCode == 0.
+
+					if (kb.VKey == VK_CONTROL && kb.MakeCode != 0)
+					{
+						if (kb.Message == WM_KEYDOWN ||
+							kb.Message == WM_SYSKEYDOWN)
+						{
+							g_PhysicalCtrlDown = true;
+						}
+						else if (kb.Message == WM_KEYUP ||
+							kb.Message == WM_SYSKEYUP)
+						{
+							g_PhysicalCtrlDown = false;
+						}
+					}
+				}
+			}
+		}
+
+	break;
+      }
+
+	case WM_MOUSEWHEEL:
+	{
+		// Keep ImGui's Ctrl state synchronized with the physical keyboard.
+		// Windows may synthesize Ctrl for touchpad pinch gestures.
+		io.AddKeyEvent(ImGuiMod_Ctrl, g_PhysicalCtrlDown);
+
+		break;
+	}
+
+    }
 
     switch (msg)
     {


### PR DESCRIPTION
## Summary

This PR adds native touchpad pinch-to-zoom support for the FFT-window display area on Windows and Linux.

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/189cdc8c-977f-4d15-9200-c9d48f2455d5" />


The goal is to provide smooth and granular zoom control using the touchpad pinch gesture, while preserving the existing mouse wheel and two-finger scrolling behavior.

## Windows

- Adds touchpad pinch-to-zoom support.
- Distinguishes the Ctrl generated by the Windows touchpad pinch gesture from a physical Ctrl key.
- Physical Ctrl continues to inhibit zoom as before.

## Linux / X11

- Adds native pinch gesture support using XInput2 (XI2).
- Uses `XI_GesturePinchBegin`, `XI_GesturePinchUpdate`, and `XI_GesturePinchEnd`.
- XInput2 is loaded dynamically.
- XI2 gesture support is enabled only when XInput2 2.4 or newer is available.
- The code can be compiled with XInput2 support disabled, preserving the previous behavior.

## Tested

Tested successfully on Windows 11 and Linux (X11):

- Mouse wheel zoom in/out (existing behavior)
- Two-finger touchpad scrolling up/down (existing behavior)
- Touchpad pinch zoom in/out — spreading or bringing two fingers together (new feature)
- Ctrl + mouse wheel — zoom inhibited (existing behavior)
- Ctrl + two-finger scrolling — zoom inhibited (existing behavior)
- Ctrl + pinch — zoom inhibited (new behavior)

The Linux build was also tested with `IMGUI_IMPL_GLFW_HAS_XINPUT2=0` to verify that the application still builds and works normally without the new XI2 pinch support.

## macOS

macOS support is not included in this PR because I don't currently have a Mac available for development and testing.