### PR TITLE
Fix abnormal exit on Linux caused by JFFT header mismatch

### DIFF
--- a/src/core/app.h
+++ b/src/core/app.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "dsp/iq_ring.h"
-#include "dsp/jfft.h"
+#include "jfft.h"
 #include "gui/waterfall.h"
 #include "sdr/rtl_sdr_source.h"
 #include "sdr/hackrf_source.h"


### PR DESCRIPTION
This fixes an abnormal exit on Linux caused by a mismatch between two different `JFFT` definitions.

`src/core/app.h` was including:

```cpp
#include "dsp/jfft.h"
```

while CMake links `third_party/jaero_dsp/jfft.cpp`, whose `JFFT` class has a different internal layout.

The local `src/dsp/jfft.h` uses `std::vector` members for the FFT tables, while `third_party/jaero_dsp/jfft.h` uses `std::shared_ptr<std::vector<...>>` backed by a shared table pool.

This caused undefined behaviour and memory corruption. On Linux it appeared when closing InmarScope as:

```text
./build/InmarScope
munmap_chunk(): invalid pointer
Abortado 
```

GDB traced the failure to `JFFT::~JFFT()`, and AddressSanitizer reported an invalid free involving the mismatched `JFFT` layout.

The fix is simply to include the header that matches the implementation already linked by CMake:

```diff
-#include "dsp/jfft.h"
+#include "jfft.h"
```

Tested this PR on Linux with:

* AddressSanitizer: clean exit after this fix, with no invalid free
```text
./build/InmarScope   (now, when exit program on linux ,  no error message at all  , completely clean) 
```

* Several FFT sizes, including 4096, 8192, 16384 and 32768
* Spectrum and waterfall working correctly across FFT size changes
* 600, 1200 and 10500 baud decoding
* Multiple active decoders
* Aero message decoding
* 8400 bps voice decoding from recorded IQ signals

No DSP regression observed.

@SarahRoseLives, could you also please confirm that this header change has no other side effects beyond what I have tested, or suggest any additional tests that would be useful?

Cheers,
José Luis
